### PR TITLE
Fix several panics

### DIFF
--- a/gonanoid.go
+++ b/gonanoid.go
@@ -2,6 +2,7 @@ package gonanoid
 
 import (
 	"crypto/rand"
+	"fmt"
 	"math"
 )
 
@@ -44,6 +45,13 @@ func getMask(alphabet string, masks []uint) int {
 
 // Generate is a low-level function to change alphabet and ID size.
 func Generate(alphabet string, size int) (string, error) {
+	if len(alphabet) == 0 || len(alphabet) > 255 {
+		return "", fmt.Errorf("alphabet must not empty and contain no more than 255 chars. Current len is %d", len(alphabet))
+	}
+	if size <= 0 {
+		return "", fmt.Errorf("size must be positive integer")
+	}
+
 	masks := initMasks(size)
 	mask := getMask(alphabet, masks)
 	ceilArg := 1.6 * float64(mask*size) / float64(len(alphabet))

--- a/gonanoid_test.go
+++ b/gonanoid_test.go
@@ -117,3 +117,26 @@ func TestChangeGenerator(t *testing.T) {
 		t.Errorf("generating nanoid with custom generator failed, expected ______ ('_' length 6) got: \"%v\"", id)
 	}
 }
+
+func TestUnacceptableAlphabetSize(t *testing.T) {
+	alphabets := []string{
+		"",                       // too short
+		strings.Repeat("a", 256), // too long
+	}
+
+	for _, alphabet := range alphabets {
+		_, err := Generate(alphabet, 32)
+		if err == nil {
+			t.Errorf("alphabet of size %d should not be allowed", len(alphabet))
+		}
+	}
+}
+
+func TestNonPositiveSize(t *testing.T) {
+	for _, size := range []int{-1, 0} {
+		_, err := Generate("alphabet", size)
+		if err == nil {
+			t.Errorf("non posisitive size (%d) should not be allowed", size)
+		}
+	}
+}


### PR DESCRIPTION
I'm playing with [go-fuzz](https://github.com/dvyukov/go-fuzz) and have found and fixed a couple of crashes in method `Generate`:
- for empty alphabet
- for non-positive size

And the hanging for alphabet of 256 chars (I didn't dive for logic, so suggested fix may be wrong)

Tests are provided