### PR TITLE
Fix go modules

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-go 1.12.3
+go 1.12
 
 module github.com/matoous/go-nanoid


### PR DESCRIPTION
Fixes the issue when using Go 1.14 

```
 go get github.com/matoous/go-nanoid@v1.1.0
go: github.com/Shopify/<readacted>@v0.0.0-20200124195044-34d9e1ffae49 requires
	github.com/matoous/go-nanoid@v1.1.0: parsing go.mod: go.mod:1: usage: go 1.23
```

In the go.mod you are not supposed to have patch versions.

cc @matoous 