### PR TITLE
Update github action config

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,11 +7,10 @@ jobs:
     steps:
       - name: Set up golang-ci lint
         env:
-          GOLANGCILINT_VERSION: 1.17.1
+          GOLANGCILINT_VERSION: 1.24.0
         run: curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $HOME/bin v${GOLANGCILINT_VERSION}
 
-      - name: Check out code
-        uses: actions/checkout@v1
+      - uses: actions/checkout@v2
 
       - name: Lint
         run: PATH="$PATH:$HOME/bin" make lint

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,14 +5,13 @@ jobs:
     name: Test
     runs-on: ubuntu-latest
     steps:
-      - name: Set up Go 1.12
+      - name: Set up Go 1.14
         uses: actions/setup-go@v1
         with:
-          go-version: 1.12.3
+          go-version: 1.14
         id: go
 
-      - name: Check out code
-        uses: actions/checkout@v1
+      - uses: actions/checkout@v2
 
       - name: Test
         run: make test
@@ -21,14 +20,13 @@ jobs:
     name: Benchmark
     runs-on: ubuntu-latest
     steps:
-      - name: Set up Go 1.12
+      - name: Set up Go 1.14
         uses: actions/setup-go@v1
         with:
-          go-version: 1.12.3
+          go-version: 1.14
         id: go
 
-      - name: Check out code
-        uses: actions/checkout@v1
+      - uses: actions/checkout@v2
 
       - name: Benchmark
         run: make bench


### PR DESCRIPTION
Since go.mod is already with go v1.14, update the github action flow to v1.14 as well.