### PR TITLE
Generate valid id for any custom alphabet

### DIFF
--- a/examples/simple_example.go
+++ b/examples/simple_example.go
@@ -7,7 +7,29 @@ import (
 )
 
 func main() {
+	// Simple usage
 	id, err := gonanoid.Nanoid()
+	if err != nil {
+		panic(err)
+	}
+	fmt.Printf("Generated id: %s\n", id)
+
+	// Custom length
+	id, err = gonanoid.ID(5)
+	if err != nil {
+		panic(err)
+	}
+	fmt.Printf("Generated id: %s\n", id)
+
+	// Custom alphabet
+	id, err = gonanoid.Generate("abcdefg", 10)
+	if err != nil {
+		panic(err)
+	}
+	fmt.Printf("Generated id: %s\n", id)
+
+	// Custom non ascii alphabet
+	id, err = gonanoid.Generate("こちんにабдежиклмнは你好喂שלום😯😪🥱😌😛äöüß", 10)
 	if err != nil {
 		panic(err)
 	}

--- a/gonanoid.go
+++ b/gonanoid.go
@@ -7,8 +7,8 @@ import (
 	"math"
 )
 
+var defaultAlphabet = []rune("_-0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")
 const (
-	defaultAlphabet = "_-0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ" // len=64
 	defaultSize     = 21
 	defaultMaskSize = 5
 )
@@ -34,7 +34,7 @@ func initMasks(params ...int) []uint {
 	return masks
 }
 
-func getMask(alphabet string, masks []uint) int {
+func getMask(alphabet []rune, masks []uint) int {
 	for i := 0; i < len(masks); i++ {
 		curr := int(masks[i])
 		if curr >= len(alphabet)-1 {
@@ -45,7 +45,9 @@ func getMask(alphabet string, masks []uint) int {
 }
 
 // Generate is a low-level function to change alphabet and ID size.
-func Generate(alphabet string, size int) (string, error) {
+func Generate(rawAlphabet string, size int) (string, error) {
+	alphabet := []rune(rawAlphabet)
+
 	if len(alphabet) == 0 || len(alphabet) > 255 {
 		return "", fmt.Errorf("alphabet must not empty and contain no more than 255 chars. Current len is %d", len(alphabet))
 	}
@@ -58,7 +60,7 @@ func Generate(alphabet string, size int) (string, error) {
 	ceilArg := 1.6 * float64(mask*size) / float64(len(alphabet))
 	step := int(math.Ceil(ceilArg))
 
-	id := make([]byte, size)
+	id := make([]rune, size)
 	bytes := make([]byte, step)
 	for j := 0; ; {
 		_, err := BytesGenerator(bytes)
@@ -97,7 +99,7 @@ func Nanoid(param ...int) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	id := make([]byte, size)
+	id := make([]rune, size)
 	for i := 0; i < size; i++ {
 		id[i] = defaultAlphabet[bytes[i]&63]
 	}


### PR DESCRIPTION
Add feature to generate valid ID for any (i hope) input alphabet. Testing with:
`id, err := gonanoid.Generate("こんにちабдежиклмнは你好喂שלום😍🤗😯😪🥱😌😛äöüß", 10)`
Output:

> дו😌ä喂שו🥱хш
> üсрф😯пюöはä
> с😍ш😪וн😍бнこ
> б😯уוöö🥱ехм
> äםфםß🥱рб喂г

Your mistake was working with string as array. Go string []operator return byte by index, not rune(char) how does this happen in JavaScript [https://developer.mozilla.org/ru/docs/Web/JavaScript/Reference/Global_Objects/String](url)