### PR TITLE
chore: bump minimum supported version to v1.21

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        version: ["1.20", "1.21", "1.22"]
+        version: ["1.21", "1.22", "1.23"]
     steps:
       - uses: actions/checkout@v4.2.1
       - uses: actions/setup-go@v5


### PR DESCRIPTION
The policy is to have latest 3 versions.
